### PR TITLE
Upload provenance report as artifact for CLI access

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -79,10 +79,14 @@ jobs:
         run: |
           echo "## Signal Provenance Report" >> $GITHUB_STEP_SUMMARY
           cat build/signal_provenance_report.md >> $GITHUB_STEP_SUMMARY
-          echo -e "\n\n## Raw JSON Data" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          cat build/signal_provenance_report.json >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload provenance report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: provenance-report
+          path: |
+            build/signal_provenance_report.md
+            build/signal_provenance_report.json
 
       - name: Checkout schemas repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds an artifact upload step for the provenance report in the daily-update workflow, making it accessible via GitHub CLI.

The changes:
- Add artifact upload step to capture provenance report (markdown and JSON)
- Remove raw JSON dump section from workflow summary

This allows downstream tools and CLI utilities to access the provenance data without cluttering the workflow summary.